### PR TITLE
Set toolbar's theme to match Anki's theme

### DIFF
--- a/src/pdf.py
+++ b/src/pdf.py
@@ -114,15 +114,12 @@ class WebViewForPdfjs(QWebEngineView):
 
     def _inject_on_loaded_script(self):
         script = QWebEngineScript()
+        css_theme = 2 if theme_manager.night_mode else 1
         script.setSourceCode("""
         document.addEventListener("webviewerloaded", () => {
             // setting disablePreferences is required to prevent preferences from overriding annotationEditorMode
-            // TODO: investigate how this affects theming and other things
-            // TODO: if those preferences are coming from localStorage as I can tell from reading pdf.js's source,
-            // investigate enabling the editor by directly setting the "pdfjs.preferences" local storage key
             PDFViewerApplicationOptions.set("disablePreferences", true);
-            // TODO: maybe set viewerCssTheme according to Anki's theme
-            //PDFViewerApplicationOptions.set("viewerCssTheme", 0);
+            PDFViewerApplicationOptions.set("viewerCssTheme", %d);
             PDFViewerApplicationOptions.set("annotationEditorMode", pdfjsLib.AnnotationEditorType.NONE);
             PDFViewerApplication.initializedPromise.then(() => {
                 PDFViewerApplication.eventBus.on("documentloaded", function () {
@@ -134,7 +131,7 @@ class WebViewForPdfjs(QWebEngineView):
                 });
             });
         });
-        """ % self.pycmd_doc_modified)
+        """ % (css_theme, self.pycmd_doc_modified))
 
         script.setInjectionPoint(QWebEngineScript.InjectionPoint.DocumentCreation)
         script.setWorldId(QWebEngineScript.ScriptWorldId.MainWorld)


### PR DESCRIPTION
It looks like the viewer's toolbar used to always be dark, but now it's always light after #6 (Because of `PDFViewerApplicationOptions.set("disablePreferences", true)`) 

This sets the the toolbar's theme according to Anki's theme.